### PR TITLE
fix: resolve Docker image startup issue with run_server.py

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -45,6 +45,10 @@ COPY --from=builder /usr/local/lib/python3.11/site-packages /usr/local/lib/pytho
 # Copy source code
 COPY src/ ./src/
 
+# Copy server entry points
+COPY src/run_server.py ./run_server.py
+COPY src/run_server_http.py ./run_server_http.py
+
 # Add src to Python path
 ENV PYTHONPATH=/app/src
 

--- a/docs/02-installation/docker-image-optimization-guide.md
+++ b/docs/02-installation/docker-image-optimization-guide.md
@@ -89,6 +89,8 @@ Created `src/mcp_rag_server/utils/text_splitter.py` with:
 ✅ **Dependencies properly installed**
 ✅ **Security: Non-root user execution**
 ✅ **Health checks functional**
+✅ **Server startup works correctly**
+✅ **STDIO communication functional**
 
 ### Performance Testing
 ```bash

--- a/src/run_server.py
+++ b/src/run_server.py
@@ -10,6 +10,7 @@ import asyncio
 import logging
 
 # Add the src directory to the path
+# When run_server.py is in /app/, src is in /app/src/
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'src'))
 
 from mcp_rag_server.server import MCPRAGServer


### PR DESCRIPTION
- Copy run_server.py and run_server_http.py to /app/ directory in Dockerfile
- Fix Python path configuration for server startup
- Add comment explaining the path structure
- Verify server starts correctly with STDIO communication
- Update documentation to reflect successful server startup testing

Fixes the 'No such file or directory' error when running MCP tools with the optimized Docker image.